### PR TITLE
feat: Add Likes, Owner and Creators to api fields

### DIFF
--- a/bfportal/core/api.py
+++ b/bfportal/core/api.py
@@ -22,6 +22,7 @@ class ExperiencePageAPIViewSet(BaseAPIViewSet):
         "exp_url",
         "featured",
         "bugged",
+        "like_count",
     ]
     listing_default_fields = body_fields
 

--- a/bfportal/core/api.py
+++ b/bfportal/core/api.py
@@ -24,6 +24,7 @@ class ExperiencePageAPIViewSet(BaseAPIViewSet):
         "bugged",
         "xp_farm",
         "like_count",
+        "exp_creators",
     ]
     listing_default_fields = body_fields
 

--- a/bfportal/core/api.py
+++ b/bfportal/core/api.py
@@ -22,6 +22,7 @@ class ExperiencePageAPIViewSet(BaseAPIViewSet):
         "exp_url",
         "featured",
         "bugged",
+        "xp_farm",
         "like_count",
     ]
     listing_default_fields = body_fields

--- a/bfportal/core/models/experience.py
+++ b/bfportal/core/models/experience.py
@@ -229,6 +229,11 @@ class ExperiencePage(RoutablePageMixin, CustomBasePage):
         + [CustomBasePage.content_panels[-1]]
     )
 
+    @property
+    def like_count(self):
+        """Return the number of likes this experience has."""
+        return self.liked_by.count()
+
     parent_page_types = ["core.ExperiencesPage"]
     subpage_types = []
 


### PR DESCRIPTION
The fields (`like_count`, `exp_creators`, `xp_farm`) were missing from the API response, this PR adds them to the public API