### PR TITLE
fix: Add CSRF_TRUSTED_ORIGINS to settings.py

### DIFF
--- a/.github/funding.yaml
+++ b/.github/funding.yaml
@@ -1,1 +1,2 @@
+github: [battlefield-portal-community]
 patreon: battlefield_portal_community

--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,0 +1,12 @@
+name: WIP
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  wip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wip/action@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bfportal/bfportal/settings/production.py
+++ b/bfportal/bfportal/settings/production.py
@@ -8,6 +8,7 @@ DEBUG = True if os.environ.get("DEBUG", "False") == "True" else False
 SECRET_KEY = os.environ.get("PRODUCTION_KEY")
 ALLOWED_HOSTS = os.environ.get("PRODUCTION_HOST").split(",")
 ALLOWED_HOSTS.append("localhost")
+CSRF_TRUSTED_ORIGINS = ["https://*.bfportal.gg/"]
 logger.debug(f"Allowed Hosts {ALLOWED_HOSTS}")
 
 try:


### PR DESCRIPTION
CSRF_TRUSTED_ORIGINS is required by Django 4.0+ to have csrf functionality.  