### PR TITLE
feat: add plan-issue and open-pr workflow skills

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: open-pr
+description: Open a GitHub PR for the current feature branch, link it to all the issues it resolves, and apply the Has PR label to each. Run this once you have real commits on a feature branch created by plan-issue. One PR typically bundles several issues.
+---
+
+# open-pr
+
+Open a pull request for the work on the current feature branch and wire it to **all** the issues it resolves, matching bfportal conventions. A feature branch usually closes multiple issues (e.g. PR #251 closed #248, #249, #250).
+
+## Preconditions
+- You are on a feature branch (not `main`), and it has at least one commit ahead of `main`.
+
+## Steps
+
+1. **Determine which issues this PR closes.** The branch is named after the feature, not an issue, so gather the set explicitly:
+   - Prefer the issue numbers created by `plan-issue` earlier in this session.
+   - Otherwise ask the user, or cross-check open issues that lack the `Has PR` label:
+     ```bash
+     gh issue list --state open --search '-label:"Has PR"'
+     ```
+   - Confirm the final list with the user before proceeding.
+
+2. **Sync the branch:**
+   ```bash
+   git push -u origin HEAD
+   ```
+
+3. **Draft the PR:**
+   - **Title**: a conventional-commit style summary of the whole feature (`feat: ...`, `fix: ...`) consistent with the repo's history.
+   - **Body**: brief summary of what changed, then a bulleted `- Closes #<N>` line **for each** issue. Use `-` list items so GitHub renders each issue's title inline:
+     ```
+     - Closes #248
+     - Closes #249
+     - Closes #250
+     ```
+
+4. **Show the user** the title, body, and the full issue list before creating — PR creation is outward-facing.
+
+5. **Create the PR** against `main`:
+   ```bash
+   gh pr create --base main --title "<title>" --body "<body>"
+   ```
+   Add `--draft` if the user says the work isn't ready for review.
+
+6. **Apply the `Has PR` label to every linked issue:**
+   ```bash
+   for n in 248 249 250; do gh issue edit "$n" --add-label "Has PR"; done
+   ```
+
+7. **Report** the PR URL and the issues it closes.
+
+## Notes
+- If some commits look unrelated to the listed issues, flag the mismatch to the user instead of forcing the links.
+- If `gh` isn't authenticated, tell the user to run `! gh auth login`.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: plan-issue
+description: Turn the feature plan from the current conversation into one or more GitHub issues and cut a feature branch. Run this AFTER a plan is agreed (e.g. after plan mode) and BEFORE writing any code. Do not use once commits exist — use open-pr for that.
+---
+
+# plan-issue
+
+Convert the plan produced in **this conversation** into well-formed GitHub issue(s) matching bfportal conventions, then cut a single feature branch to work on. A feature typically decomposes into several issues that later share one PR (e.g. #248/#249/#250 → PR #251).
+
+## Preconditions
+- A plan/spec has been discussed in this session. If no clear plan exists, ask the user to share or point to it — do NOT invent scope.
+- Working tree is clean and on `main` (or an up-to-date base). If not, tell the user and stop; don't stash or switch over uncommitted work.
+
+## Steps
+
+1. **Split the plan into issues.** One issue per logical, independently-describable change (mirror how a feature breaks into backend/models/frontend pieces). A small plan may be a single issue; don't force a split.
+
+2. **Draft each issue.** Do not re-plan; summarize what was agreed.
+   - **Title**: imperative, concise, no trailing period. E.g. `Register BF6 scripts models and add migration`.
+   - **Body**: match the house format —
+     - One plain intro line describing the change.
+     - A bulleted list of concrete specifics; wrap identifiers, files, and symbols in backticks (`` `ScriptsCategory` ``, `` `bf6.models` ``, `` `0003` ``).
+     - **No "Part of the X feature" footer** — the PR will link these issues, so the relationship is captured there.
+
+3. **Pick labels** per issue (pass each with its emoji exactly as `gh label list` shows):
+   - Exactly one `type:*` — `type:backend 🖥`, `type:frontend 🏞`, `type:style 🎨`, or `type:3rd party 🧿`. If an issue spans backend+frontend, apply both.
+   - `enhancement ✨✨` for new features/requests, `bug ⚠` for fixes.
+   - Add a priority (`0 priority: High 🥇` / `1 priority: medium 🥈` / `2 priority: Low 🥉`) only if the user stated urgency; otherwise leave unset.
+   - Do NOT add `Has PR` — that is applied by the `open-pr` skill.
+
+4. **Show the user** the drafted title/body/labels for every issue. Get a thumbs-up (or edits) before creating — issue creation is outward-facing.
+
+5. **Create the issues:**
+   ```bash
+   gh issue create --title "<title>" --body "<body>" \
+     --label "enhancement ✨✨" --label "type:backend 🖥"
+   ```
+   Capture each issue number from the returned URLs.
+
+6. **Cut ONE feature branch** from up-to-date `main`, named after the **feature** (kebab-case, descriptive — e.g. `bf6-scripts-snippets`), NOT after any issue number, since the branch/PR bundles all the issues:
+   ```bash
+   git fetch origin main
+   git switch -c <feature-slug> origin/main
+   ```
+
+7. **Report** every issue number/URL and the branch name. Note the issue numbers so the eventual `open-pr` can link them all. Do not commit or push anything.
+
+## Notes
+- Never fabricate scope not present in the discussed plan.
+- If `gh` isn't authenticated, tell the user to run `! gh auth login` rather than guessing.


### PR DESCRIPTION
Adds two project-scoped Claude Code skills that encode this repo's issue/PR workflow.

## What
- **`/plan-issue`** — run after a plan is agreed, before any code. Splits the plan into one or more labeled issues (house body format, no "part of feature" footer) and cuts a single **feature-named** branch off `main`.
- **`/open-pr`** — run once commits exist. Gathers the issues the branch resolves, opens a PR whose body lists `- Closes #N` bullets so GitHub renders each title, and applies the `Has PR` label to each issue.

## Why
Codifies the existing "one feature → many issues → one branch → one PR" convention (e.g. PR #251 closing #248/#249/#250) so it's applied consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)